### PR TITLE
Ui upgrade: file's section improved and primary button's look fixed

### DIFF
--- a/code transpiler react app/package-lock.json
+++ b/code transpiler react app/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "@mui/icons-material": "^7.1.2",
         "@mui/material": "^7.0.2",
         "axios": "^1.8.4",
         "gh-pages": "^6.3.0",
@@ -263,13 +264,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.27.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1171,26 +1169,52 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.0.2.tgz",
-      "integrity": "sha512-TfeFU9TgN1N06hyb/pV/63FfO34nijZRMqgHk0TJ3gkl4Fbd+wZ73+ZtOd7jag6hMmzO9HSrBc6Vdn591nhkAg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.1.2.tgz",
+      "integrity": "sha512-0gLO1PvbJwSYe5ji021tGj6HFqrtEPMGKK4L1zWwRbhzrWWUumUJvMvJUsIgWQIYQsgOnhq9k2Fc1BxLGHDsAg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
-    "node_modules/@mui/material": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.0.2.tgz",
-      "integrity": "sha512-rjJlJ13+3LdLfobRplkXbjIFEIkn6LgpetgU/Cs3Xd8qINCCQK9qXQIjjQ6P0FXFTPFzEVMj0VgBR1mN+FhOcA==",
+    "node_modules/@mui/icons-material": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.1.2.tgz",
+      "integrity": "sha512-slqJByDub7Y1UcokrM17BoMBMvn8n7daXFXVoTv0MEH5k3sHjmsH8ql/Mt3s9vQ20cORDr83UZ448TEGcbrXtw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/core-downloads-tracker": "^7.0.2",
-        "@mui/system": "^7.0.2",
-        "@mui/types": "^7.4.1",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.1.2",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.1.2.tgz",
+      "integrity": "sha512-Z5PYKkA6Kd8vS04zKxJNpwuvt6IoMwqpbidV7RCrRQQKwczIwcNcS8L6GnN4pzFYfEs+N9v6co27DmG07rcnoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.1",
+        "@mui/core-downloads-tracker": "^7.1.2",
+        "@mui/system": "^7.1.1",
+        "@mui/types": "^7.4.3",
+        "@mui/utils": "^7.1.1",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
@@ -1209,7 +1233,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.0.2",
+        "@mui/material-pigment-css": "^7.1.1",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1230,13 +1254,13 @@
       }
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.0.2.tgz",
-      "integrity": "sha512-6lt8heDC9wN8YaRqEdhqnm0cFCv08AMf4IlttFvOVn7ZdKd81PNpD/rEtPGLLwQAFyyKSxBG4/2XCgpbcdNKiA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.1.1.tgz",
+      "integrity": "sha512-M8NbLUx+armk2ZuaxBkkMk11ultnWmrPlN0Xe3jUEaBChg/mcxa5HWIWS1EE4DF36WRACaAHVAvyekWlDQf0PQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1",
+        "@mui/utils": "^7.1.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1257,12 +1281,12 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.0.2.tgz",
-      "integrity": "sha512-11Bt4YdHGlh7sB8P75S9mRCUxTlgv7HGbr0UKz6m6Z9KLeiw1Bm9y/t3iqLLVMvSHYB6zL8X8X+LmfTE++gyBw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.1.1.tgz",
+      "integrity": "sha512-R2wpzmSN127j26HrCPYVQ53vvMcT5DaKLoWkrfwUYq3cYytL6TQrCH8JBH3z79B6g4nMZZVoaXrxO757AlShaw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
+        "@babel/runtime": "^7.27.1",
         "@emotion/cache": "^11.13.5",
         "@emotion/serialize": "^1.3.3",
         "@emotion/sheet": "^1.4.0",
@@ -1291,16 +1315,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.0.2.tgz",
-      "integrity": "sha512-yFUraAWYWuKIISPPEVPSQ1NLeqmTT4qiQ+ktmyS8LO/KwHxB+NNVOacEZaIofh5x1NxY8rzphvU5X2heRZ/RDA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.1.1.tgz",
+      "integrity": "sha512-Kj1uhiqnj4Zo7PDjAOghtXJtNABunWvhcRU0O7RQJ7WOxeynoH6wXPcilphV8QTFtkKaip8EiNJRiCD+B3eROA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/private-theming": "^7.0.2",
-        "@mui/styled-engine": "^7.0.2",
-        "@mui/types": "^7.4.1",
-        "@mui/utils": "^7.0.2",
+        "@babel/runtime": "^7.27.1",
+        "@mui/private-theming": "^7.1.1",
+        "@mui/styled-engine": "^7.1.1",
+        "@mui/types": "^7.4.3",
+        "@mui/utils": "^7.1.1",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1331,12 +1355,12 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.1.tgz",
-      "integrity": "sha512-gUL8IIAI52CRXP/MixT1tJKt3SI6tVv4U/9soFsTtAsHzaJQptZ42ffdHZV3niX1ei0aUgMvOxBBN0KYqdG39g==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.3.tgz",
+      "integrity": "sha512-2UCEiK29vtiZTeLdS2d4GndBKacVyxGvReznGXGr+CzW/YhjIX+OHUdCIczZjzcRAgKBGmE9zCIgoV9FleuyRQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0"
+        "@babel/runtime": "^7.27.1"
       },
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1348,13 +1372,13 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.0.2.tgz",
-      "integrity": "sha512-72gcuQjPzhj/MLmPHLCgZjy2VjOH4KniR/4qRtXTTXIEwbkgcN+Y5W/rC90rWtMmZbjt9svZev/z+QHUI4j74w==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.1.1.tgz",
+      "integrity": "sha512-BkOt2q7MBYl7pweY2JWwfrlahhp+uGLR8S+EhiyRaofeRYUWL2YKbSGQvN4hgSN1i8poN0PaUiii1kEMrchvzg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.0",
-        "@mui/types": "^7.4.1",
+        "@babel/runtime": "^7.27.1",
+        "@mui/types": "^7.4.3",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -1768,9 +1792,9 @@
       "license": "MIT"
     },
     "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "license": "MIT"
     },
     "node_modules/@types/react": {
@@ -3941,12 +3965,6 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/code transpiler react app/package.json
+++ b/code transpiler react app/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "@mui/icons-material": "^7.1.2",
     "@mui/material": "^7.0.2",
     "axios": "^1.8.4",
     "gh-pages": "^6.3.0",
@@ -32,6 +33,6 @@
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.24.1",
     "vite": "^6.2.0"
-  }, 
+  },
   "homepage": "https://sanidhya-dobhal.github.io/Python-to-C-transpiler/"
 }

--- a/code transpiler react app/src/App.css
+++ b/code transpiler react app/src/App.css
@@ -1,0 +1,4 @@
+.MuiAccordion-region a{
+    display:block;
+    margin-bottom:4px;
+}

--- a/code transpiler react app/src/App.tsx
+++ b/code transpiler react app/src/App.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import EditorComponent from "./Components/EditorComponent";
 import axios from "axios";
-import { Button, Tabs, Tab, Box } from "@mui/material";
+import './App.css';
+import { Button, Tabs, Tab, Box, Accordion, AccordionSummary } from "@mui/material";
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LinkComponent from "./Components/CustomComponents/LinkComponent";
 
 function App() {
@@ -83,6 +85,17 @@ function App() {
       await transpileCode(pythonCode, "python", "c");
     }
   }
+
+  function downloadFinalCode(){
+     const link = document.createElement("a");
+    link.href = finalCCode;
+    link.download = "Equivalent C Code.c";
+    link.style.display = "none";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  }
+  
   function handleLanguageChange(event: any) {
     if (event.target.textContent !== selectedLanguageTab) {
       if (event.target.textContent === "C") {
@@ -125,9 +138,15 @@ function App() {
           setEditorValue={setEditorValue}
           selectedLanguage={selectedLanguageTab}
         />
-        <Button onClick={onClickSubmit}>Transpile</Button>
+        <Button variant = "contained"onClick={onClickSubmit} style = {{marginTop:8}}>Transpile</Button>
       </div>
-      <div>
+      <div style ={{width:'100%',marginTop:48}}>
+      <div style = {{display:finalCCode?'block':'none',marginRight: 32, marginLeft:32}}>
+        <Button variant="outlined" onClick ={downloadFinalCode} fullWidth>Download C Code</Button>
+        <Accordion style={{marginTop:16}}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <b style = {{color: 'rgb(0, 82, 165)'}}>Supporting files</b>
+            </AccordionSummary>
         <LinkComponent
           file={codeWithoutComm}
           downloadName="CodeWithoutComments.py"
@@ -153,14 +172,11 @@ function App() {
           downloadName="StatementCategory.txt"
           anchorText="Download statement categories file"
         />
-        <LinkComponent
-          file={finalCCode}
-          downloadName="Equivalent C Code.c"
-          anchorText="Download Equivalent C Code"
-        />
+        </Accordion>
+        </div>
         {error && (
           <div>
-            <p style={{ color: "red", margin: "0 16px" }}>{error}</p>
+            <p style={{ color: "red", margin: "0" , textAlign:"center"}} >{error}</p>
           </div>
         )}
       </div>

--- a/code transpiler react app/src/Components/CustomComponents/LinkComponent.tsx
+++ b/code transpiler react app/src/Components/CustomComponents/LinkComponent.tsx
@@ -17,7 +17,6 @@ export default function LinkComponent({
         <Link href={file} download={downloadName}>
           {anchorText}
         </Link>
-        <br></br>
       </>
     )
   );

--- a/code transpiler react app/src/main.tsx
+++ b/code transpiler react app/src/main.tsx
@@ -1,6 +1,5 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(


### PR DESCRIPTION
#6 's "improved the supporting files section UI"
- Provided a button to download only the final C final which is same as the C code in the editor. 
- Added an accordian for supporting files which makes the UI look much cleaner now
- changed the look of the "Transple" button to make it the primiary button on the page

Before: 
<img width="540" alt="Screenshot 2025-06-29 at 4 49 04 AM" src="https://github.com/user-attachments/assets/34ea8783-1fb1-4997-a830-c4561f0d78ae" />
After

<img width="540" alt="Screenshot 2025-06-29 at 4 52 58 AM" src="https://github.com/user-attachments/assets/1241fdad-096c-4ce4-b1f6-0e2546ed0043" />
