### PR TITLE
#6-UI upgrade: adding heading and tooltip component and repositioning…

### DIFF
--- a/code transpiler react app/src/App.css
+++ b/code transpiler react app/src/App.css
@@ -1,4 +1,21 @@
+body{
+    font-family: Arial;
+    margin: 0px;
+    padding-left: 32px;
+}
 .MuiAccordion-region a{
     display:block;
     margin-bottom:4px;
+    margin-left: 16px;
+}
+.MuiCollapse-wrapperInner div[role="region"]{
+    padding-bottom:16px;
+}
+.MuiAccordion-heading button span {
+    align-items:center;
+    justify-content: space-between;
+}
+.MuiAccordion-heading button span:nth-child(1) svg {
+    color:gray;
+    height:20px;
 }

--- a/code transpiler react app/src/App.tsx
+++ b/code transpiler react app/src/App.tsx
@@ -5,6 +5,7 @@ import './App.css';
 import { Button, Tabs, Tab, Box, Accordion, AccordionSummary } from "@mui/material";
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import LinkComponent from "./Components/CustomComponents/LinkComponent";
+import InfoToolTipComponent from "./Components/InfoToolTipComponent";
 
 function App() {
   const [codeWithoutComm, setcodeWithoutComm] = useState<string>();
@@ -115,7 +116,8 @@ function App() {
     }
   }
   const [editorValue, setEditorValue] = useState('print("Hello World")');
-  return (
+  return (<>
+    <h1 style = {{marginTop:32, marginBottom: 8}}>Python to C Transpiler</h1>
     <div style={{ display: "flex", flexDirection: "row" }}>
       <div>
         <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
@@ -138,14 +140,17 @@ function App() {
           setEditorValue={setEditorValue}
           selectedLanguage={selectedLanguageTab}
         />
-        <Button variant = "contained"onClick={onClickSubmit} style = {{marginTop:8}}>Transpile</Button>
+        <div style = {{display:'flex',flexDirection:'row',marginTop:8,gap:8}}>
+        <Button variant = "contained"onClick={onClickSubmit}>Transpile</Button>
+        {finalCCode && <Button variant="outlined" onClick ={downloadFinalCode}>Download C Code</Button>}
+        </div>
       </div>
       <div style ={{width:'100%',marginTop:48}}>
       <div style = {{display:finalCCode?'block':'none',marginRight: 32, marginLeft:32}}>
-        <Button variant="outlined" onClick ={downloadFinalCode} fullWidth>Download C Code</Button>
-        <Accordion style={{marginTop:16}}>
+        <Accordion>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <b style = {{color: 'rgb(0, 82, 165)'}}>Supporting files</b>
+            <InfoToolTipComponent  title= "Intermediate output files generated during transpilation to help better understand and debug each compilation phase" placement= "top" />
             </AccordionSummary>
         <LinkComponent
           file={codeWithoutComm}
@@ -181,6 +186,7 @@ function App() {
         )}
       </div>
     </div>
+    </>
   );
 }
 

--- a/code transpiler react app/src/Components/EditorComponent.tsx
+++ b/code transpiler react app/src/Components/EditorComponent.tsx
@@ -18,9 +18,9 @@ export default function EditorComponent({
   }
   }
   return (
-    <div style={{ border: "2px solid #7f7f7f", minHeight: 300, width: "80vw" }}>
+    <div style={{ border: "2px solid #7f7f7f", minHeight: 300, width: "76vw" }}>
       <Editor
-        height="87vh"
+        height="78vh"
         language = {selectedLanguage.toLowerCase()}
         value={editorValue}
         onChange={editorChangeHandler}

--- a/code transpiler react app/src/Components/InfoToolTipComponent.tsx
+++ b/code transpiler react app/src/Components/InfoToolTipComponent.tsx
@@ -1,0 +1,10 @@
+import { PopperProps, Tooltip } from '@mui/material'
+import InfoOutlineSharpIcon from '@mui/icons-material/InfoOutlineSharp';
+
+export default function InfoToolTipComponent({title,placement}:{title:string,placement:PopperProps['placement']|undefined}) {
+  return (
+        <Tooltip title = {title} placement= {placement}>
+        <InfoOutlineSharpIcon />
+        </Tooltip>
+  )
+}


### PR DESCRIPTION
Adding heading, tooltip for supporting files and repositioned the Download C Code button to complete #6  all parts. 
Before: 
<img width="1440" alt="Screenshot 2025-07-01 at 11 56 45 PM" src="https://github.com/user-attachments/assets/05fdc72b-1a33-4b6c-afe5-b9d8c0cff868" />

After: 
<img width="1440" alt="Screenshot 2025-07-01 at 11 58 06 PM" src="https://github.com/user-attachments/assets/66515116-2939-4bad-8c36-94f14b9ca022" />

