### PR TITLE
#12- now string assingment for single quotes is supported 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Python to C code convertor tool
 This tool validates the python source code and if the code has no errors, it it converted to C
 
-🧩 **This repository is a monorepo** containing both frontend and backend code for the application.
+🧩 **This repository is a monorepo** containing both frontend and backend code,  along with some test cases for validation and reliability.
 ## 🚀 Live Demo
 [Python to C Transpiler](https://sanidhya-dobhal.github.io/Python-to-C-transpiler/)
 ## ✨ Features supported
@@ -16,11 +16,36 @@ This tool validates the python source code and if the code has no errors, it it 
 - ✅ Flags unterminated multi-line comments, preventing malformed translations
 - ❌ Does not currently support control flow constructs (e.g., `if`, `while`, `for`) – planned for future
 
+## 🧪 Test Cases
+This monorepo includes some test cases covering valid and invalid Python code snippets to ensure accurate and safe transpilation.
+
+Why test cases matter:
+- 🧷 Reliability: Users can refer to these tests to analyse which scenarios are supported.
+
+- 🧪 Consistency: **Contributors should run the test cases locally and on the hosted version** before pushing any changes to ensure they don't unintentionally break existing features.
+
+- 🧰 Extensibility: The test cases serve as a useful base for anyone looking to extend the transpiler or enhance its accuracy.
+
+📌 Test scripts and sample inputs are organized in the ```Test cases/```
+Please refer to the contributing section for how to use them during development.
 
 ##  🧮 Logics
 - ### Numeric assignments
     - Numeric assignments are the ones with alternating variables or numerical literals and arithematic operators in the RHS. 
     - Additionally the last token should not be arithematic operator
+
+- ### String assignments 
+    - Simple string assignments with enclosed in double quotes("") or single quotes('') are supported. 
+    - The ```syntaxGrammerChecker``` strictly checks if a line of code (LOC) contains exactly 5 tokens and adheres to one of the following forms:
+    <pre> <code>identifier = "string"</code> </pre>
+    OR
+    <pre><code?>identifier = 'string'</code> </pre> </code></pre>
+    <details><summary>Why are string assignments limited to these formats only ?</summary>
+    This transpiler is intentionally designed for simple transpilations. In C, string manipulation—such as concatenation—requires using functions like strcat() from the string.h library. Implementing full support for all string assignment variations (e.g., dynamic concatenation) would significantly increase complexity. Hence, for now, only basic assignments are allowed to maintain reliability and clarity during transpilation.
+
+</details>
+</details>
+
 ## 📦Technologies used 
 
  - __For frontend:__ <u>React.js with TypeScript</u>, Material UI component library, Monaco Code Editor
@@ -35,7 +60,8 @@ Feel free to:
 
 - 💬 Propose a new issue or enhancement — Please let me know before opening a new issue as there are many features that I do not currently intend to implement. 
 
+- 🧪 Run test cases before submitting changes — this helps ensure no breaking changes are introduced
+
 - 📬 Reach out directly if you want to discuss a feature, a bug, or just talk about compiler design or transpilers in general.
 
-Whether you're a beginner or an experienced developer, your input is appreciated!
-
+Whether you're a beginner or an experienced developer, your input is appreciated 🥂!

--- a/Test cases/stringAssignments.py
+++ b/Test cases/stringAssignments.py
@@ -1,0 +1,4 @@
+#This test case is for making sure that both single-quote and double-quotes assignments for strings work
+a = "Hello"
+b = 'World'
+print (a,b)

--- a/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
+++ b/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
@@ -120,6 +120,9 @@ function instructionGenerator(
     }
     outputLine += identifier + " = ";
     for (let tokenIndex in RHSTokens) {
+      if( RHSTokens[tokenIndex] ==="'")
+        outputLine += "\"";
+      else 
       outputLine += RHSTokens[tokenIndex];
     }
   } else if (statementType === "✅ Print statement") {

--- a/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/CommentRemover.ts
+++ b/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/CommentRemover.ts
@@ -54,7 +54,7 @@ export function commentRemover(sourceCode: string):string | {
             continue;
           }
           else{
-            return {error:'SyntaxError: unterminated triple-quoted string detected'}
+            return {error:'SyntaxError: unterminated triple-quoted string detected.(Looks like you have not closed your multi-lined comment)'}
           }
         } else {
           // it's just a single quote or something else, preserve it

--- a/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/LexemeGenerator.ts
+++ b/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/LexemeGenerator.ts
@@ -5,7 +5,6 @@ export function lexemeGenerator(
     //push the new lexeme and flush the variable
     if (lex.length > 0) {
       output.push(lex);
-      console.log(lex);
       lex = "";
       i = 0;
     }
@@ -23,15 +22,11 @@ export function lexemeGenerator(
       appendLex(); // Flush previous token
       output.push('"');
       index++;
-      let hasStringTerminated = false
       while (index < inputCode.length && inputCode[index] !== '"' && inputCode[index]!='\n') {
         lex += inputCode[index];
         index++;
       }
-      if(inputCode[index]==='"'){
-        hasStringTerminated = true;
-      }
-      else{
+      if(!(inputCode[index]==='"')) {
         return {error: "SyntaxError: Unterminated string detected in lexical analysis"}
       }
       output.push(lex);
@@ -39,7 +34,23 @@ export function lexemeGenerator(
       lex = "";
       output.push('"');
       //   index++;
-    } else if (isPunct(ch)) {
+    } else if(ch ==="'") {
+      appendLex(); // Flush previous token
+      output.push("'");
+      index++;
+      let hasStringTerminated = false;
+      while (index < inputCode.length && inputCode[index] !== "'" && inputCode[index]!='\n') {
+        lex += inputCode[index];
+        index++;
+      }
+      if(!(inputCode[index] === "'")) {
+        return {error: "SyntaxError: Unterminated string detected in lexical analysis"}
+      }
+      output.push(lex);
+      lex = "";
+      output.push("'");
+    } 
+    else if (isPunct(ch)) {
       appendLex();
       const nextCh = inputCode[index + 1] ?? "";
       if (["=", "!", "<", ">"].includes(ch)) {

--- a/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/tokenClassifier.ts
+++ b/code-transpiler-backend/src/CompilerPhases/lexicalAnaysis/tokenClassifier.ts
@@ -40,7 +40,8 @@ const python_keywords = [
 ];
 export function tokenClassifier(lexemeLines: string[][]): TokenInfo[][] {
   const result: TokenInfo[][] = [];
-  let make_string_flag = false;
+  let makeStringFlag = false;
+  let startingQuotes: ''|'"'|"'" = '';
 
   for (const line of lexemeLines) {
     const processedLine: TokenInfo[] = [];
@@ -49,10 +50,10 @@ export function tokenClassifier(lexemeLines: string[][]): TokenInfo[][] {
       let tokenType = "";
       const isKeyword = python_keywords.includes(token);
 
-      if (make_string_flag) {
-        if (token === '"') {
-          tokenType = 'punctuation"';
-          make_string_flag = false;
+      if (makeStringFlag) {
+        if (token === startingQuotes && startingQuotes!== '') {
+          tokenType = "punctuation" + token;
+          makeStringFlag = false;
         } else {
           tokenType = "string_literal";
         }
@@ -76,7 +77,13 @@ export function tokenClassifier(lexemeLines: string[][]): TokenInfo[][] {
             break;
           case '"':
             tokenType = 'punctuation"';
-            make_string_flag = true;
+            makeStringFlag = true;
+            startingQuotes = '"';
+            break;
+            case "'":
+            tokenType = "punctuation'";
+            makeStringFlag = true;
+            startingQuotes = "'";
             break;
           default:
             tokenType = "punctuation" + token;

--- a/code-transpiler-backend/src/CompilerPhases/syntaxGrammerChecker.ts
+++ b/code-transpiler-backend/src/CompilerPhases/syntaxGrammerChecker.ts
@@ -12,10 +12,10 @@ export function syntaxGrammarCheck(lines: string[]): string[] {
     else if (words[0] === "identifier" && words[1] === "Assign_op") {
       // Possible string assignment
       if (
-        words.length === 5 &&
-        words[2] === 'punctuation"' &&
-        words[3] === "string_literal" &&
-        words[4] === 'punctuation"'
+        words.length === 5 && 
+        ((words[2] === 'punctuation"' && words[3] === "string_literal" && words[4] ==='punctuation"')
+        ||
+        (words[2] === "punctuation'" && words[3] === "string_literal" && words[4] === "punctuation'"))
       ) {
         results.push("✅ String assignment");
         flag = true;


### PR DESCRIPTION
Single quotes strings assignments are now supported and also errors that are already handled for double-quotes strings haved also been handled for single quotes strings. 
Changes made are:
- in [LexemeGenerator.ts](https://github.com/Sanidhya-Dobhal/Python-to-C-transpiler/compare/%2312-string-assignments-fix?expand=1#diff-4cf21fcc2246b670c5ef6c3a9cbfc95fc4da709b5e361a72ef02df44d4aa8bef), code for `SyntaxError: Unterminated string detected in lexical analysis` has been added. 
- In [tokenClassifier.ts](https://github.com/Sanidhya-Dobhal/Python-to-C-transpiler/compare/%2312-string-assignments-fix?expand=1#diff-0394db1f93cf3c81d6c64afd20702ccec44c52bbf65292a4b5c0cca5a7dd720d), the string inside single quotes was getting classified as identifier instead of string literal. Codes changes have been made to handle that. 
- Other changes are simple changes that were required. 