### PR TITLE
#12 single quotes' strings in print function are now supported

### DIFF
--- a/Test cases/stringAssignments.py
+++ b/Test cases/stringAssignments.py
@@ -1,4 +1,4 @@
 #This test case is for making sure that both single-quote and double-quotes assignments for strings work
 a = "Hello"
 b = 'World'
-print (a,b)
+print (a,b, "python", 'to C')

--- a/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
+++ b/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
@@ -159,7 +159,7 @@ function instructionGenerator(
           templateString+="%f ";
         }
       }
-      printArgumentsString += printContent[tokenIndexNumber];
+      printArgumentsString += printContent[tokenIndexNumber] ==="'" ? '"':printContent[tokenIndexNumber];
     }
   } else if(statementType ==="✅ New line"){
     return "\n";

--- a/code-transpiler-backend/src/CompilerPhases/syntaxGrammerChecker.ts
+++ b/code-transpiler-backend/src/CompilerPhases/syntaxGrammerChecker.ts
@@ -2,41 +2,39 @@ export function syntaxGrammarCheck(lines: string[]): string[] {
   const results: string[] = [];
 
   for (const line of lines) {
-    const words = line.trim().split(/\s+/);
+    const wordsInLOC = line.trim().split(/\s+/);
     let flag = false;
 
-    if(words.length==1 && words[0]==='')
+    if(wordsInLOC.length==1 && wordsInLOC[0]==='')
     {
       results.push('✅ New line');
     }
-    else if (words[0] === "identifier" && words[1] === "Assign_op") {
+    else if (wordsInLOC[0] === "identifier" && wordsInLOC[1] === "Assign_op") {
       // Possible string assignment
       if (
-        words.length === 5 && 
-        ((words[2] === 'punctuation"' && words[3] === "string_literal" && words[4] ==='punctuation"')
-        ||
-        (words[2] === "punctuation'" && words[3] === "string_literal" && words[4] === "punctuation'"))
+        wordsInLOC.length === 5 && 
+       checkQuotedStringLiteralFromTokens(wordsInLOC, 2)
       ) {
         results.push("✅ String assignment");
         flag = true;
       } else {
         // Check for numeric expression assignment
         flag = true;
-        for (let i = 2; i < words.length; i++) {
-          if (i === words.length - 1) {
+        for (let i = 2; i < wordsInLOC.length; i++) {
+          if (i === wordsInLOC.length - 1) {
             //last token can't be a Arth_operator
-            if (words[i] === "Arth_operator") {
+            if (wordsInLOC[i] === "Arth_operator") {
               flag = false;
               break;
             }
           }
           if (i % 2 === 0) {
-            if (!(words[i] === "num_literal" || words[i] === "identifier")) {
+            if (!(wordsInLOC[i] === "num_literal" || wordsInLOC[i] === "identifier")) {
               flag = false;
               break;
             }
           } else {
-            if (words[i] !== "Arth_operator") {
+            if (wordsInLOC[i] !== "Arth_operator") {
               flag = false;
               break;
             }
@@ -44,29 +42,27 @@ export function syntaxGrammarCheck(lines: string[]): string[] {
         }
         results.push(flag ? "✅ Numeric assignment" : `❌ Invalid syntax`);
       }
-    } else if (words[0] === "print_func" && words[1] === "punctuation(") {
+    } else if (wordsInLOC[0] === "print_func" && wordsInLOC[1] === "punctuation(") {
       let validPrint = false;
-      if(words.length===3 && words[2]==="punctuation)"){//For "print()"
+      if(wordsInLOC.length===3 && wordsInLOC[2]==="punctuation)"){//For "print()"
         validPrint =true;
       }
       let i = 2;
-      while (i < words.length) {
-        if (words[i] === "identifier" || words[i] === "num_literal") {
+      while (i < wordsInLOC.length) {
+        if (wordsInLOC[i] === "identifier" || wordsInLOC[i] === "num_literal") {
           validPrint = true;
           i++;
         } else if (
-          words[i] === 'punctuation"' &&
-          words[i + 1] === "string_literal" &&
-          words[i + 2] === 'punctuation"'
+          checkQuotedStringLiteralFromTokens(wordsInLOC, i)
         ) {
           validPrint = true;
           i += 3;
-        } else if (words[i] === "punctuation,") {
+        } else if (wordsInLOC[i] === "punctuation,") {
           validPrint = false;
           i++;
         } else if (
-          words[i] === "punctuation)" &&
-          i === words.length - 1 &&
+          wordsInLOC[i] === "punctuation)" &&
+          i === wordsInLOC.length - 1 &&
           validPrint
         ) {
           flag = true;
@@ -83,4 +79,12 @@ export function syntaxGrammarCheck(lines: string[]): string[] {
   }
 
   return results;
+}
+
+function checkQuotedStringLiteralFromTokens(wordsInLOC:string[], startIndex:number) {
+  return  (
+    (wordsInLOC[startIndex] === 'punctuation"' && wordsInLOC[startIndex + 1] === "string_literal" && wordsInLOC[startIndex + 2] ==='punctuation"')
+    ||
+    (wordsInLOC[startIndex] === "punctuation'" && wordsInLOC[startIndex + 1] === "string_literal" && wordsInLOC[startIndex + 2] === "punctuation'")
+    );
 }


### PR DESCRIPTION
Chages made
- single quotes in print function are now allowed and are correctly getting transpiled to C
- Changed variable words' name to wordsInLOC which makes more sense. 
- Added function `checkQuotedStringLiteralFromTokens` to check for both the types of string assignment in a more reusable manner which is used in both string assignment syntax check and print function's assignment check