### PR TITLE
Added Sub-directory Readme #26

### DIFF
--- a/Test cases/README.md
+++ b/Test cases/README.md
@@ -1,0 +1,53 @@
+# **Test Cases – Python to C Transpiler**
+
+###### This directory contains Python code samples used to verify the correctness, reliability, and limitations of the transpilation process from Python to C.
+---
+## Purpose
+
+- Ensure supported syntax is correctly transpiled
+- Detect unsupported features and raise appropriate errors
+- Enable regression testing for contributors
+- Provide reusable examples for development and debugging
+---
+## Folder Structure
+```
+est cases/
+├── DegreeToFarenheit.py # Valid: arithmetic + print
+├── stringAssignments.py # Valid: single & double quote strings
+├── Swapping_2_variables.py # Valid: variable reassignment
+├── testCaseInput1.py # Mixed types, repeated logic
+├── testCaseInput2.py # Edge case: empty print
+└── Error cases/
+```
+---
+
+## Usage Instructions
+
+1. Start the **backend** (`npm start`) and **frontend** (`npm run dev`)
+2. Copy the contents of any test case into the frontend editor
+3. Check the output:
+   - **Tokens**, **symbol table**, and **final C code** should display for valid files
+   - **Errors** should be shown for unsupported/invalid cases
+---
+## Sample Test Categories
+
+### Valid Tests
+- Simple numeric assignments
+- String assignments with `'` or `"`
+- Basic arithmetic expressions
+- Standard print statements
+
+### Invalid / Edge Case Ideas
+- Unterminated strings or comments
+- Variables used before assignment
+- Unsupported syntax (`if`, `for`, `while`, etc.)
+---
+## Contributing New Tests
+
+- Add new `.py` files for test cases
+- Use descriptive file names
+- Keep each test small and focused on one concept
+- For invalid cases, place them under `Error cases/` for clarity
+
+---
+

--- a/code transpiler react app/README.md
+++ b/code transpiler react app/README.md
@@ -1,0 +1,64 @@
+# **Frontend – Python to C Transpiler React App**
+
+This is the frontend interface for the Python-to-C transpiler tool. It provides a browser-based environment where users can input Python code, submit it for analysis and transpilation, and receive the equivalent C code along with intermediate outputs like tokens and symbol tables.
+
+## Features
+
+- **Live Code Editor** powered by Monaco
+- **Transpiles Python to C** using the backend API
+- Shows:
+  - Lexical analysis results
+  - Token classification
+  - Syntax validation output
+  - Symbol table
+  - Final transpiled C code
+- Displays error messages for invalid code
+
+## Tech Stack
+
+- **React.js** with **TypeScript**
+- **Material UI** – for styling and layout
+- **Monaco Editor** – for code editing
+- **Axios** – for communicating with backend API
+- **Vite** – build tool
+
+## Live App
+
+[Python to C Transpiler (Hosted)](https://sanidhya-dobhal.github.io/Python-to-C-transpiler/)
+
+## Scripts
+
+```bash
+npm install        # Install dependencies
+npm run dev        # Start development server
+npm run build      # Build for production
+npm run preview    # Preview the built app locally
+npm run lint       # Lint the code
+npm run deploy     # Deploy to GitHub Pages
+```
+---
+## Development Notes
+* Make sure the backend (`code-transpiler-backend`) is running locally on port `5000`
+* The frontend uses Axios to send code to `/api/transpile` endpoint
+* Adjust API base URL in code if backend is hosted elsewhere
+---
+## Directory Overview
+```arduino
+code_transpiler_react_app/
+├── public/
+├── src/
+│   ├── App.tsx
+│   ├── main.tsx
+│   └── components/
+├── index.html
+├── package.json
+├── tsconfig.app.json
+├── vite.config.ts
+└── ...
+```
+---
+## Before Pushing
+* Test the UI thoroughly
+* Validate error handling for various edge cases
+* Ensure consistency with backend responses
+---

--- a/code-transpiler-backend/README.md
+++ b/code-transpiler-backend/README.md
@@ -1,0 +1,70 @@
+# **Backend – Python to C Transpiler**
+
+This is the backend service that powers the Python-to-C transpiler tool. It handles lexical analysis, syntax validation, and generates equivalent C code for supported Python statements.
+
+## What It Does
+
+The backend performs a multi-phase compilation process:
+
+1. **Comment Removal** – strips out all comments from Python code
+2. **Lexical Analysis** – breaks input into lexemes
+3. **Token Classification** – identifies token types (identifier, operator, etc.)
+4. **Syntax Grammar Check** – validates supported Python grammar
+5. **Symbol Table Construction** – stores variable names and types
+6. **Code Generation** – produces equivalent C code for valid input
+
+## API Endpoint
+
+### `POST /api/transpile`
+
+**Payload:**
+```json
+{
+  "sourceCode": "x = 5\nprint(x)",
+  "sourceLang": "python",
+  "targetLang": "c"
+}
+```
+### Returns:
+* Transpiled C code
+* Lexical output
+* Token list
+* Syntax evaluation
+* Symbol table
+* Error messages (if any)
+---
+## Technologies used
+* Node.js
+* Express.js
+* TypeScript
+
+### Run Locally
+```bash
+npm install
+npm start      # Runs on http://localhost:5000
+```
+---
+## Directory Structure
+```pgsql
+code-transpiler-backend/
+├── src/
+│   ├── CompilerPhases/
+│   │   ├── lexicalAnaysis/
+│   │   ├── syntaxGrammerChecker.ts
+│   │   ├── codeGenerator.ts
+│   ├── index.ts
+│   └── OutputFilesGenerator.ts
+├── package.json
+└── tsconfig.json
+```
+---
+## Limitations
+* Control structures (`if`, `while`, `for`) are not yet supported
+* Focuses on simple numeric and string assignments
+* Only supports basic `print()` statements
+---
+## Developer Notes
+* You can test with files from the `Test cases/` folder
+* Update logic inside `CompilerPhases/` for grammar or lexeme rules
+* If modifying outputs, sync the frontend to reflect those changes
+---


### PR DESCRIPTION
# **Add README.md Files for Sub-Directories (#26 )**
This PR addresses [Issue #26](https://github.com/Sanidhya-Dobhal/Python-to-C-transpiler/issues/26) by adding dedicated README.md files for each of the main sub-directories in this monorepo.
---
## Changes Made
### code_transpiler_react_app/README.md
→ Describes the frontend built with React, usage instructions, tech stack, and contribution tips.

### code-transpiler-backend/README.md
→ Covers the backend's functionality, API endpoint, internal structure, and development info.

### Test cases/README.md
→ Documents the purpose of test cases, usage instructions, file descriptions, and how to contribute new cases.
---
## Motivation
Having README files at the sub-directory level:
* Improves discoverability and maintainability
* Helps contributors understand each module independently
* Aligns with best practices for monorepo documentation
---
## How to Review
Open each README.md and verify:
* Structure matches the actual codebase
* Information is accurate and complete
* Markdown formatting renders correctly on GitHub
---
## Related Issue
Closes #26 
---
@Sanidhya-Dobhal Please Check, Review and merge

Thank You