### PR TITLE
#29 Fix: change error message to match Python NameError format

### DIFF
--- a/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
+++ b/code-transpiler-backend/src/CompilerPhases/codeGenerator.ts
@@ -188,6 +188,6 @@ function getVariableDetails(identifier: string,detail:"cVariable"|"datatype") {
       }
     }
   } else {
-    return { error: `Invalid variable: ${identifier}` };
+    return { error: `NameError: name '${identifier}' is not defined` };
   }
 }


### PR DESCRIPTION
## Summary
Changed the error message for undefined variables from `Invalid variable: ${identifier}` to `NameError: name '${identifier}' is not defined` to match Python's standard error format.

## Fix
In `code-transpiler-backend/src/CompilerPhases/codeGenerator.ts`, line 191:

**Before:**
```typescript
return { error: `Invalid variable: ${identifier}` };
```

**After:**
```typescript
return { error: `NameError: name '${identifier}' is not defined` };
```

## Testing
As shown in issue #29, when accessing an undefined variable `b` in Python, Python shows:
```
NameError: name 'b' is not defined
```

The transpiler should follow the same convention.

Fixes #29